### PR TITLE
Use current project version as default in `darkrift pull`

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -214,6 +214,12 @@ namespace DarkRift.Cli
                 }
             }
 
+            // if version provided is "latest", it is being replaced with currently most recent one
+            if (opts.Version == "latest")
+            {
+                opts.Version = VersionManager.GetLatestDarkRiftVersion();
+            }
+
             string path = VersionManager.GetInstallationPath(opts.Version, opts.Tier ? ServerTier.Pro : ServerTier.Free, opts.Platform);
 
             if (path == null)

--- a/Program.cs
+++ b/Program.cs
@@ -57,7 +57,7 @@ namespace DarkRift.Cli
         [Verb("pull", HelpText = "Pulls the specified version of DarkRift locally.")]
         class PullOptions
         {
-            [Value(0, Required = true)]
+            [Value(0, Required = false)]
             public String Version { get; set; }
 
             [Option('p', "pro", Default = false, HelpText = "Use the pro version.")]
@@ -196,6 +196,24 @@ namespace DarkRift.Cli
 
         private static int Pull(PullOptions opts)
         {
+            if (string.IsNullOrEmpty(opts.Version))
+            {
+                // if version info was omitted, overwrite any parameters with current project settings
+                if (Project.IsCurrentDirectoryAProject())
+                {
+                    var project = Project.Load();
+
+                    opts.Version = project.Runtime.Version;
+                    opts.Platform = project.Runtime.Platform;
+                    opts.Tier = project.Runtime.Tier == ServerTier.Pro;
+                }
+                else
+                {
+                    Console.Error.WriteLine(Output.Red($"You can perform this command only in a project directory."));
+                    return 2;
+                }
+            }
+
             string path = VersionManager.GetInstallationPath(opts.Version, opts.Tier ? ServerTier.Pro : ServerTier.Free, opts.Platform);
 
             if (path == null)

--- a/Project.cs
+++ b/Project.cs
@@ -57,5 +57,15 @@ namespace DarkRift.Cli
                 ser.WriteObject(writer, this);
             }
         }
+
+        /// <summary>
+        /// Returns if the current directory is the directory where project is located
+        /// by checking existence of Project.xml file.
+        /// </summary>
+        /// <returns>Returns if the current directory is a project directory</returns>
+        public static bool IsCurrentDirectoryAProject()
+        {
+            return File.Exists("Project.xml");
+        }
     }
 }


### PR DESCRIPTION
Allows empty version in `darkrift pull` command, defaulting to the current version of the current project.

However, it was required to change `--version` parameter to `-v` in PullCommand, as `--version` is already one of the defaults of CommandLineParser (and is showing darkrift-cli version information).

Closes #5.